### PR TITLE
set android.software.leanback required to false

### DIFF
--- a/leanbackcards/src/main/AndroidManifest.xml
+++ b/leanbackcards/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     package="com.hitherejoe.leanbackcards"
     tools:ignore="MissingLeanbackLauncher">
 
-    <uses-feature android:name="android.software.leanback" android:required="true"/>
+    <uses-feature android:name="android.software.leanback" android:required="false"/>
 
     <application tools:ignore="AllowBackup,GoogleAppIndexingWarning,MissingApplicationIcon" />
 


### PR DESCRIPTION
This is so this can be used with apps that use this can work on devices other than TVs like https://github.com/googlesamples/android-UniversalMusicPlayer
